### PR TITLE
Fix missing enum from merged schema

### DIFF
--- a/bin/mergeSchema.py
+++ b/bin/mergeSchema.py
@@ -29,6 +29,8 @@ def buildSchema(schema, enum, plus):
         enum['actor']['external']['variety']
     schema['properties']['actor']['properties']['internal']['properties']['variety']['items']['enum'] = \
         enum['actor']['internal']['variety']
+    schema['properties']['actor']['properties']['internal']['properties']['job_change']['items']['enum'] = \
+        enum['actor']['internal']['job_change']
     schema['properties']['actor']['properties']['external']['properties']['country']['items']['enum'] = enum['country']
     schema['properties']['actor']['properties']['partner']['properties']['country']['items']['enum'] = enum['country']
 

--- a/verisc-merged.json
+++ b/verisc-merged.json
@@ -849,6 +849,20 @@
           "properties": {
             "job_change": {
               "items": {
+                "enum": [
+                  "Hired", 
+                  "Promoted", 
+                  "Lateral move", 
+                  "Resigned", 
+                  "Let go", 
+                  "Demoted", 
+                  "Passed over", 
+                  "Unknown", 
+                  "Other", 
+                  "Reprimanded", 
+                  "Job eval", 
+                  "Personal issues"
+                ], 
                 "type": "string"
               }, 
               "minItems": 1, 


### PR DESCRIPTION
mergeSchema.py wasn't merging in the enums for actor.internal.job_change. Now it will.
