### PR TITLE
fix small typo in employee counts in enums.html

### DIFF
--- a/enums.html
+++ b/enums.html
@@ -246,7 +246,7 @@
                                 <p><b>10001 to 25000: </b>10,001 to 25,000 employees</p>
                                 <p><b>25001 to 50000: </b>25,001 to 50,000 employees</p>
                                 <p><b>50001 to 100000: </b>50,001 to 100,000 employees</p>
-                                <p><b>Over 100000: </b>Over 100,0001 employees</p>
+                                <p><b>Over 100000: </b>Over 100,000 employees</p>
                                 <p><b>Small: </b>Small organizations (1,000 employees or less)</p>
                                 <p><b>Large: </b>Large organizations (over 1,000 employees)</p>
                                 <p><b>Unknown: </b>Unknown number of employees</p>


### PR DESCRIPTION
a one-character commit to delete the extraneous `1` that appears in the employee counts enumeration.

hope everyone's doing well :)
